### PR TITLE
Use env var for token rather than creating a file

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   codeql-build-and-publish:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       - name: Checkout Repository
@@ -26,5 +28,5 @@ jobs:
             cd /app/zeta-protocol-checks && \
             codeql pack install && \
             codeql pack create -v . && \
-            echo '${{ secrets.GITHUB_TOKEN }}' | codeql pack publish --github-auth-stdin
+            codeql pack publish
           "

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,7 +26,5 @@ jobs:
             cd /app/zeta-protocol-checks && \
             codeql pack install && \
             codeql pack create -v . && \
-            echo '${{ secrets.GITHUB_TOKEN }}' > /tmp/token.txt && \
-            codeql pack publish --github-auth-stdin < /tmp/token.txt && \
-            rm -f /tmp/token.txt
+            echo '${{ secrets.GITHUB_TOKEN }}' | codeql pack publish --github-auth-stdin
           "


### PR DESCRIPTION
Rather than the current multistep process to handle the GitHub token, using a pipe would be preferable.