### PR TITLE
Keep token off disk

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,15 +2,14 @@ name: CI/CD with CodeQL
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+    types: [closed]
 
 jobs:
   codeql-build-and-publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,19 +2,16 @@ name: CI/CD with CodeQL
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+    types: [closed]
 
 jobs:
   codeql-build-and-publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
+    
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -24,11 +21,9 @@ jobs:
 
       - name: Publish CodeQL Pack inside the docker container
         run: |
-          docker run --rm -v ${{ github.workspace }}:/app codeql-runner bash -c "
+          docker run --rm -e GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }} '-v ${{ github.workspace }}:/app codeql-runner bash -c "
             cd /app/zeta-protocol-checks && \
             codeql pack install && \
             codeql pack create -v . && \
-            echo '${{ secrets.GITHUB_TOKEN }}' > /tmp/token.txt && \
-            codeql pack publish --github-auth-stdin < /tmp/token.txt && \
-            rm -f /tmp/token.txt
+            codeql pack publish
           "

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,10 +21,8 @@ jobs:
         run: docker build -t codeql-runner .
 
       - name: Publish CodeQL Pack using File-Based Token (Fixed)
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          docker run --rm -v ${{ github.workspace }}:/app codeql-runner bash -c "
+          docker run -e GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' --rm -v ${{ github.workspace }}:/app codeql-runner bash -c "
             cd /app/zeta-protocol-checks && \
             codeql pack install && \
             codeql pack create -v . && \

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,9 +12,7 @@ on:
 jobs:
   codeql-build-and-publish:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
+    
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -23,6 +21,8 @@ jobs:
         run: docker build -t codeql-runner .
 
       - name: Publish CodeQL Pack using File-Based Token (Fixed)
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           docker run --rm -v ${{ github.workspace }}:/app codeql-runner bash -c "
             cd /app/zeta-protocol-checks && \

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Build Docker Image
         run: docker build -t codeql-runner .
 
-      - name: Publish CodeQL Pack inside the docker container
+      - name: Publish CodeQL Pack using File-Based Token (Fixed)
         run: |
-          docker run --rm -e GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }} '-v ${{ github.workspace }}:/app codeql-runner bash -c "
+          docker run -e GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' --rm -v ${{ github.workspace }}:/app codeql-runner bash -c "
             cd /app/zeta-protocol-checks && \
             codeql pack install && \
             codeql pack create -v . && \

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build Docker Image
         run: docker build -t codeql-runner .
 
-      - name: Publish CodeQL Pack using File-Based Token (Fixed)
+      - name: Publish CodeQL Pack inside the docker container
         run: |
           docker run -e GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' --rm -v ${{ github.workspace }}:/app codeql-runner bash -c "
             cd /app/zeta-protocol-checks && \


### PR DESCRIPTION
This PR is designed to:
- Keep GITHUB_TOKEN off disk during publish
- Limit the build and publish workflow to merges to main from a merged PR.